### PR TITLE
modified reset() for I2C sharing with other sensors

### DIFF
--- a/Adafruit_MAX1704X.cpp
+++ b/Adafruit_MAX1704X.cpp
@@ -95,6 +95,10 @@ uint8_t Adafruit_MAX17048::getChipID(void) {
   return ic_vers.read();
 }
 
+/*!
+ *    @brief  Soft reset the MAX1704x
+ *    @return True on reset success
+ */
 bool Adafruit_MAX17048::reset(void) {
   Adafruit_BusIO_Register cmd =
       Adafruit_BusIO_Register(i2c_dev, MAX1704X_CMD_REG, 2, MSBFIRST);

--- a/Adafruit_MAX1704X.cpp
+++ b/Adafruit_MAX1704X.cpp
@@ -99,7 +99,7 @@ bool Adafruit_MAX17048::reset(void) {
   Adafruit_BusIO_Register cmd =
       Adafruit_BusIO_Register(i2c_dev, MAX1704X_CMD_REG, 2, MSBFIRST);
 
-  // send reset command, the MAX1704 will reset before ACKing, 
+  // send reset command, the MAX1704 will reset before ACKing,
   // so I2C xfer is expected to *fail* with a NACK
   if (cmd.write(0x5400)) {
     return false;

--- a/Adafruit_MAX1704X.cpp
+++ b/Adafruit_MAX1704X.cpp
@@ -95,19 +95,25 @@ uint8_t Adafruit_MAX17048::getChipID(void) {
   return ic_vers.read();
 }
 
-/*!
- *    @brief  Soft reset the MAX1704x
- *    @return True on reset success
- */
 bool Adafruit_MAX17048::reset(void) {
   Adafruit_BusIO_Register cmd =
       Adafruit_BusIO_Register(i2c_dev, MAX1704X_CMD_REG, 2, MSBFIRST);
-  if (cmd.write(0x5400)) {
-    return false; // This should *fail*
-  }
-  // aha! we NACKed, which is CORRECT!
 
-  return clearAlertFlag(MAX1704X_ALERTFLAG_RESET_INDICATOR);
+  // the actual reset, this should *fail*
+  if (cmd.write(0x5400)) {
+    return false;
+  }
+
+  // loop and attempt to clear alert until success
+  for (uint8_t retries=0; retries<3; retries++) {
+    if (clearAlertFlag(MAX1704X_ALERTFLAG_RESET_INDICATOR)) {
+      return true;
+    }
+    // add retry delay?
+  }
+
+  // something didn't work :(
+  return false;
 }
 
 /*!

--- a/Adafruit_MAX1704X.cpp
+++ b/Adafruit_MAX1704X.cpp
@@ -99,13 +99,14 @@ bool Adafruit_MAX17048::reset(void) {
   Adafruit_BusIO_Register cmd =
       Adafruit_BusIO_Register(i2c_dev, MAX1704X_CMD_REG, 2, MSBFIRST);
 
-  // the actual reset, this should *fail*
+  // send reset command, the MAX1704 will reset before ACKing, 
+  // so I2C xfer is expected to *fail* with a NACK
   if (cmd.write(0x5400)) {
     return false;
   }
 
   // loop and attempt to clear alert until success
-  for (uint8_t retries=0; retries<3; retries++) {
+  for (uint8_t retries = 0; retries < 3; retries++) {
     if (clearAlertFlag(MAX1704X_ALERTFLAG_RESET_INDICATOR)) {
       return true;
     }


### PR DESCRIPTION
reset() driver code provided by @caternusen. Tested on ESP32-S3 Rev TFT with SHT41. Code compiled and ran without any timeout or error messages. Previous releases were not allowing the MAX17048  to initialize with SHTXX temperature sensors or SGP40 gas sensors (probably others too). 